### PR TITLE
Warn if plugin loader paths don't exist

### DIFF
--- a/src/Impostor.Server/Plugins/PluginLoader.cs
+++ b/src/Impostor.Server/Plugins/PluginLoader.cs
@@ -24,6 +24,8 @@ namespace Impostor.Server.Plugins
             // Add the plugins and libraries.
             var pluginPaths = new List<string>(config.Paths);
             var libraryPaths = new List<string>(config.LibraryPaths);
+            CheckPaths(pluginPaths);
+            CheckPaths(libraryPaths);
 
             var rootFolder = Directory.GetCurrentDirectory();
 
@@ -118,6 +120,18 @@ namespace Impostor.Server.Plugins
             });
 
             return builder;
+        }
+
+        private static void CheckPaths(IEnumerable<string> paths)
+        {
+            foreach (var path in paths)
+            {
+                if (!Directory.Exists(path))
+                {
+                    Logger.Warning("Directory \"{path}\" was specified in the PluginLoader configuration, but this directory doesn't exist!", path);
+                }
+            }
+
         }
 
         private static void RegisterAssemblies(

--- a/src/Impostor.Server/Plugins/PluginLoader.cs
+++ b/src/Impostor.Server/Plugins/PluginLoader.cs
@@ -131,7 +131,6 @@ namespace Impostor.Server.Plugins
                     Logger.Warning("Directory \"{path}\" was specified in the PluginLoader configuration, but this directory doesn't exist!", path);
                 }
             }
-
         }
 
         private static void RegisterAssemblies(


### PR DESCRIPTION
### Description

This is a common misconfiguration for AUProximity users. Warn more explicitly.

<!-- 

If your pull request closes any issues, add them below with the `closes` keyword before them 

Example: closes #101

See the following article for more information: https://docs.github.com/en/free-pro-team@latest/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword

-->
