### PR TITLE
Load files directly when loading assemblies

### DIFF
--- a/src/Impostor.Server/Plugins/AssemblyInformation.cs
+++ b/src/Impostor.Server/Plugins/AssemblyInformation.cs
@@ -23,14 +23,10 @@ namespace Impostor.Server.Plugins
 
         public Assembly Load(AssemblyLoadContext context)
         {
-            if (_assembly != null)
+            if (_assembly == null)
             {
-                return _assembly;
+                _assembly = Assembly.LoadFile(Path);
             }
-
-            using var stream = File.Open(Path, FileMode.Open, FileAccess.Read, FileShare.Read);
-
-            _assembly = context.LoadFromStream(stream);
 
             return _assembly;
         }


### PR DESCRIPTION

### Description

Previously this used file streams, which made it very picky with regard
to versions. Apparently if you load it directly it starts ignoring the
minor versions.

<!-- 

If your pull request closes any issues, add them below with the `closes` keyword before them 

Example: closes #101

See the following article for more information: https://docs.github.com/en/free-pro-team@latest/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword

-->
